### PR TITLE
Canvas Rename & Real Collaborator Names

### DIFF
--- a/canvas/apps/http-backend/package.json
+++ b/canvas/apps/http-backend/package.json
@@ -4,9 +4,9 @@
 	"description": "",
 	"main": "index.js",
 	"scripts": {
+		"start": "dotenv -e ../../supabase2.env -- node dist/index.js",
 		"test": "vitest",
 		"build": "tsc -b",
-		"start": "node ./dist/index.js",
 		"dev": "npm run build && npm run start"
 	},
 	"dependencies": {
@@ -26,6 +26,7 @@
 		"@supabase/supabase-js": "^2.90.1",
 		"@types/express": "^5.0.6",
 		"@types/supertest": "^6.0.3",
+		"dotenv-cli": "^11.0.0",
 		"supertest": "^7.2.2",
 		"tsx": "^4.21.0",
 		"vitest": "^4.0.18"

--- a/canvas/apps/http-backend/src/controller/canvas.ts
+++ b/canvas/apps/http-backend/src/controller/canvas.ts
@@ -56,9 +56,14 @@ export const updateCanvas = async (req: Request, res: Response) => {
 		throw new HttpError("Room ID is required", StatusCodes.BAD_REQUEST);
 	}
 
-	const { data } = parsedData.data;
+	if (!req.user) {
+		throw new HttpError("Unauthorized", StatusCodes.UNAUTHORIZED);
+	}
+	const userId = req.user.id;
 
-	await updateCanvasService(roomId, data);
+	const { name, data } = parsedData.data;
+
+	await updateCanvasService(roomId, { name, data }, userId);
 
 	return JSONResponse(res, StatusCodes.OK, "Canvas updated successfully");
 };

--- a/canvas/apps/http-backend/src/services/canvas.ts
+++ b/canvas/apps/http-backend/src/services/canvas.ts
@@ -39,20 +39,6 @@ export const createCanvasService = async (
 	return data;
 };
 
-export const updateCanvasService = async (
-	canvasId: string,
-	data: string,
-): Promise<void> => {
-	const { error } = await serviceClient
-		.from("canvases")
-		.update({ data })
-		.eq("id", canvasId);
-
-	if (error) {
-		throw new HttpError(error.message, StatusCodes.INTERNAL_SERVER_ERROR);
-	}
-};
-
 export const getCanvasesService = async (
 	userId: string,
 ): Promise<Tables<"canvases">[]> => {
@@ -116,13 +102,32 @@ export const getCanvasService = async (
 	return data;
 };
 
+export const updateCanvasService = async (
+	canvasId: string,
+	update: { name?: string; data?: string },
+	userId: string,
+): Promise<void> => {
+	const updateFields: Record<string, string | undefined> = {};
+	if (update.name !== undefined) updateFields.name = update.name;
+	if (update.data !== undefined) updateFields.data = update.data;
+
+	const { error } = await serviceClient
+		.from("canvases")
+		.update(updateFields)
+		.eq("id", canvasId)
+		.eq("owner_id", userId);
+	if (error) {
+		throw new HttpError(error.message, StatusCodes.INTERNAL_SERVER_ERROR);
+	}
+};
+
 export const deleteCanvasService = async (
 	canvasId: string,
 	userId: string,
 ): Promise<void> => {
 	const { error } = await serviceClient
 		.from("canvases")
-		.update({ is_deleted: true, deleted_at: new Date().toISOString() })
+		.update({ is_deleted: true })
 		.eq("id", canvasId)
 		.eq("owner_id", userId);
 

--- a/canvas/packages/common/src/types.ts
+++ b/canvas/packages/common/src/types.ts
@@ -21,7 +21,8 @@ export type SigninType = z.infer<typeof SigninSchema>;
 export type CreateCanvasType = z.infer<typeof CreateCanvasSchema>;
 
 export const UpdateCanvasSchema = z.object({
-	data: z.string(),
+	name: z.string().min(1).max(50).optional(),
+	data: z.string().optional(),
 });
 
 export type UpdateCanvasType = z.infer<typeof UpdateCanvasSchema>;

--- a/canvas/pnpm-lock.yaml
+++ b/canvas/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
+      dotenv-cli:
+        specifier: ^11.0.0
+        version: 11.0.0
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
@@ -1676,8 +1679,20 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dotenv-cli@11.0.0:
+    resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
+    hasBin: true
+
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
+    engines: {node: '>=12'}
+
   dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
+    engines: {node: '>=12'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
   dotenv@17.2.3:
@@ -4448,7 +4463,20 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dotenv-cli@11.0.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      dotenv: 17.2.3
+      dotenv-expand: 12.0.3
+      minimist: 1.2.8
+
+  dotenv-expand@12.0.3:
+    dependencies:
+      dotenv: 16.6.1
+
   dotenv@16.0.3: {}
+
+  dotenv@16.6.1: {}
 
   dotenv@17.2.3: {}
 


### PR DESCRIPTION
Summary
This PR implements canvas renaming functionality and real collaborator name display for LekhaFlow canvas, enabling users to rename their canvases inline and see actual names of collaborators instead of generic identifiers. #14 

Features Implemented
Canvas Renaming (Inline Editing)
Editable title input in the canvas header
Click to edit canvas name directly (no modal dialogs)
Auto-save on blur - saves to backend when focus is lost
"Last edited" timestamp with relative time formatting (e.g., "5m ago", "Yesterday", "Feb 9")
Saving indicator - displays "Saving..." during API request
Transparent placeholder text "Untitled Canvas" for unnamed canvases
Real Collaborator Names
Yjs Awareness sync - broadcasts user's real name and color to all collaborators
Cursor name labels - each collaborator's cursor now shows their actual name
Avatar stack in header - displays collaborator initials with unique colors
User count badge - shows total number of people in the room
Names update in real-time when users join/leave
Backend Canvas Update Service
updateCanvasService
 for updating canvas name and/or data
Owner validation - only the canvas owner can rename
PUT /api/v1/canvas/:id endpoint for canvas updates
Proper error handling with HttpError responses
Technical Details
Canvas Rename Flow
User types in the title input field
On blur, 
handleBlur()
 fetches a fresh session token
Sends PUT request with { name: canvasName } to backend
Updates local updatedAt timestamp on success
Collaborator Name Sync Flow
On Yjs connection, user's identity is set via awareness.setLocalStateField("user", { name, color })
Other clients receive awareness updates and extract collaborator info
setCollaborators() updates the store with real names
CollaboratorCursors
 component renders name labels next to each cursor