### PR TITLE
Fix: Canvas interaction bugs - laser, freedraw, layering and rotation

### DIFF
--- a/canvas/apps/web/components/canvas/RotationControls.tsx
+++ b/canvas/apps/web/components/canvas/RotationControls.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import type { KonvaEventObject } from "konva/lib/Node";
+import { useState } from "react";
+import { Circle, Group, Line, Path } from "react-konva";
+
+interface RotationControlsProps {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	elementId: string;
+	zoom: number;
+	scrollX: number;
+	scrollY: number;
+	onRotate90: (elementId: string) => void;
+	onRotationStart: (elementId: string, e: KonvaEventObject<MouseEvent>) => void;
+	onRotationMove: (
+		elementId: string,
+		angle: number,
+		e: KonvaEventObject<MouseEvent>,
+	) => void;
+	onRotationEnd: (elementId: string) => void;
+}
+
+const HANDLE_SIZE = 10;
+const BUTTON_SIZE = 24;
+const HANDLE_COLOR = "#6965db";
+const HANDLE_STROKE = "#ffffff";
+const BUTTON_BG = "#ffffff";
+const HANDLE_OFFSET = 40; // Distance above element
+
+export function RotationControls({
+	x,
+	y,
+	width,
+	height,
+	elementId,
+	zoom,
+	scrollX,
+	scrollY,
+	onRotate90,
+	onRotationStart,
+	onRotationMove,
+	onRotationEnd,
+}: RotationControlsProps) {
+	const [isDragging, setIsDragging] = useState(false);
+	const centerX = x + width / 2;
+	const centerY = y + height / 2;
+
+	// Calculate rotation handle position (above the rotation button)
+	const handleY = y - HANDLE_OFFSET - BUTTON_SIZE;
+	const handleX = centerX;
+
+	// Calculate rotation button position (above element)
+	const buttonY = y - HANDLE_OFFSET / 2;
+	const buttonX = centerX;
+
+	// Circular arrow icon (cleaner design matching reference)
+	const rotateIconPath = `
+		M 6 -2
+		A 5 5 0 1 1 1 3
+		L 1 0
+		L 4 3
+		L 1 3
+		Z
+	`;
+
+	return (
+		<>
+			{/* Connection line from element to rotation controls */}
+			<Line
+				points={[centerX, y, centerX, handleY]}
+				stroke={HANDLE_COLOR}
+				strokeWidth={1}
+				dash={[4, 4]}
+				listening={false}
+			/>
+
+			{/* 90° Rotation Button */}
+			<Group
+				x={buttonX}
+				y={buttonY}
+				onClick={(e) => {
+					e.cancelBubble = true;
+					onRotate90(elementId);
+				}}
+				onMouseEnter={(e) => {
+					const container = e.target.getStage()?.container();
+					if (container) container.style.cursor = "pointer";
+				}}
+				onMouseLeave={(e) => {
+					const container = e.target.getStage()?.container();
+					if (container) container.style.cursor = "default";
+				}}
+			>
+				{/* Button background */}
+				<Circle
+					radius={BUTTON_SIZE / 2}
+					fill={BUTTON_BG}
+					stroke={HANDLE_COLOR}
+					strokeWidth={2}
+					shadowColor="rgba(0,0,0,0.2)"
+					shadowBlur={4}
+					shadowOffset={{ x: 0, y: 2 }}
+				/>
+
+				{/* Rotation icon - circular arrow */}
+				<Path
+					data={rotateIconPath}
+					fill={HANDLE_COLOR}
+					scaleX={1.2}
+					scaleY={1.2}
+				/>
+			</Group>
+
+			{/* Arbitrary Rotation Drag Handle */}
+			<Circle
+				x={handleX}
+				y={handleY}
+				radius={HANDLE_SIZE / 2}
+				fill={isDragging ? "#8b7cf6" : HANDLE_COLOR}
+				stroke={HANDLE_STROKE}
+				strokeWidth={2}
+				draggable
+				onMouseEnter={(e) => {
+					const container = e.target.getStage()?.container();
+					if (container) container.style.cursor = "grab";
+				}}
+				onMouseLeave={(e) => {
+					const container = e.target.getStage()?.container();
+					if (container) container.style.cursor = "default";
+				}}
+				onDragStart={(e) => {
+					e.cancelBubble = true;
+					setIsDragging(true);
+					const container = e.target.getStage()?.container();
+					if (container) container.style.cursor = "grabbing";
+					onRotationStart(
+						elementId,
+						e as unknown as KonvaEventObject<MouseEvent>,
+					);
+				}}
+				onDragMove={(e) => {
+					e.cancelBubble = true;
+
+					// Get mouse position in screen coordinates
+					const stage = e.target.getStage();
+					const screenPos = stage?.getPointerPosition();
+					if (!screenPos) return;
+
+					// Convert screen coordinates to canvas coordinates
+					// Stage transforms: canvas = (screen - scroll) / zoom
+					const canvasMouseX = (screenPos.x - scrollX) / zoom;
+					const canvasMouseY = (screenPos.y - scrollY) / zoom;
+
+					// Calculate angle from element center (in canvas coordinates) to mouse position (now in canvas coordinates)
+					const dx = canvasMouseX - centerX;
+					const dy = canvasMouseY - centerY;
+					const angleRad = Math.atan2(dy, dx);
+					const angleDeg = (angleRad * 180) / Math.PI + 90; // Offset by 90 to make top = 0°
+
+					// Normalize to 0-360
+					const normalizedAngle = ((angleDeg % 360) + 360) % 360;
+
+					onRotationMove(
+						elementId,
+						normalizedAngle,
+						e as unknown as KonvaEventObject<MouseEvent>,
+					);
+				}}
+				onDragEnd={(e) => {
+					e.cancelBubble = true;
+					setIsDragging(false);
+					const container = e.target.getStage()?.container();
+					if (container) container.style.cursor = "default";
+					onRotationEnd(elementId);
+				}}
+			/>
+		</>
+	);
+}

--- a/canvas/apps/web/components/canvas/Toolbar.tsx
+++ b/canvas/apps/web/components/canvas/Toolbar.tsx
@@ -8,6 +8,7 @@
 
 "use client";
 
+import type { Tool } from "@repo/common";
 import {
 	ArrowUpRight,
 	Circle,
@@ -17,23 +18,12 @@ import {
 	Minus,
 	MousePointer2,
 	Pencil,
+	Pointer,
 	Square,
 	Type,
 } from "lucide-react";
 import React from "react";
 import { useCanvasStore } from "../../store/canvas-store";
-
-type Tool =
-	| "selection"
-	| "rectangle"
-	| "ellipse"
-	| "diamond"
-	| "line"
-	| "arrow"
-	| "freedraw"
-	| "text"
-	| "eraser"
-	| "hand";
 
 interface ToolDefinition {
 	id: Tool;
@@ -78,8 +68,14 @@ const TOOLS: ToolDefinition[] = [
 	{
 		id: "freedraw",
 		icon: <Pencil size={18} />,
-		label: "Freedraw",
+		label: "Freehand",
 		shortcut: "P",
+	},
+	{
+		id: "laser",
+		icon: <Pointer size={18} />,
+		label: "Laser",
+		shortcut: "K",
 	},
 	{ id: "text", icon: <Type size={18} />, label: "Text", shortcut: "T" },
 	{ id: "eraser", icon: <Eraser size={18} />, label: "Eraser", shortcut: "E" },
@@ -101,7 +97,7 @@ export function Toolbar() {
 								<div className="w-8 h-px bg-gray-200 mx-auto my-1" />
 							)}
 							{/* Separator before eraser */}
-							{index === 8 && (
+							{index === 9 && (
 								<div className="w-8 h-px bg-gray-200 mx-auto my-1" />
 							)}
 

--- a/canvas/apps/web/components/ui/Input.tsx
+++ b/canvas/apps/web/components/ui/Input.tsx
@@ -4,7 +4,7 @@ export interface InputProps
 	extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-	({ className = "", type, ...props }, ref) => {
+	({ className = "", type = "text", ...props }, ref) => {
 		return (
 			<input
 				type={type}

--- a/canvas/apps/web/lib/element-utils.ts
+++ b/canvas/apps/web/lib/element-utils.ts
@@ -89,6 +89,7 @@ function createBaseElement(
 		updated: Date.now(),
 		link: null,
 		locked: options.locked ?? DEFAULT_ELEMENT_PROPS.locked,
+		zIndex: options.zIndex ?? 0,
 	};
 }
 

--- a/canvas/apps/web/lib/stroke-utils.ts
+++ b/canvas/apps/web/lib/stroke-utils.ts
@@ -71,7 +71,77 @@ export function calculateSpeed(
 // ============================================================================
 
 /**
+ * Calculate perpendicular distance from point to line segment
+ */
+function perpendicularDistance(
+	point: [number, number],
+	lineStart: [number, number],
+	lineEnd: [number, number],
+): number {
+	const [px, py] = point;
+	const [x1, y1] = lineStart;
+	const [x2, y2] = lineEnd;
+
+	const dx = x2 - x1;
+	const dy = y2 - y1;
+
+	if (dx === 0 && dy === 0) {
+		return Math.hypot(px - x1, py - y1);
+	}
+
+	const t = ((px - x1) * dx + (py - y1) * dy) / (dx * dx + dy * dy);
+	const projX = x1 + Math.max(0, Math.min(1, t)) * dx;
+	const projY = y1 + Math.max(0, Math.min(1, t)) * dy;
+
+	return Math.hypot(px - projX, py - projY);
+}
+
+/**
+ * Ramer-Douglas-Peucker algorithm for path simplification
+ * Reduces point count while preserving shape
+ *
+ * @param points - Array of points to simplify
+ * @param epsilon - Maximum distance threshold (higher = more aggressive)
+ * @returns Simplified points array
+ */
+export function simplifyPath(
+	points: Array<[number, number]>,
+	epsilon = 2.0,
+): Array<[number, number]> {
+	if (points.length < 3) return points;
+
+	const firstPoint = points[0];
+	const lastPoint = points[points.length - 1];
+	if (!firstPoint || !lastPoint) return points;
+
+	// Find point with maximum distance from line
+	let maxDistance = 0;
+	let maxIndex = 0;
+
+	for (let i = 1; i < points.length - 1; i++) {
+		const point = points[i];
+		if (!point) continue;
+		const distance = perpendicularDistance(point, firstPoint, lastPoint);
+		if (distance > maxDistance) {
+			maxDistance = distance;
+			maxIndex = i;
+		}
+	}
+
+	// If max distance is greater than epsilon, recursively simplify
+	if (maxDistance > epsilon) {
+		const left = simplifyPath(points.slice(0, maxIndex + 1), epsilon);
+		const right = simplifyPath(points.slice(maxIndex), epsilon);
+		return [...left.slice(0, -1), ...right];
+	}
+
+	// Return only endpoints
+	return [firstPoint, lastPoint];
+}
+
+/**
  * Optimize stroke points by reducing redundant points
+ * Simple distance-based optimization
  */
 export function optimizeStroke(
 	points: Array<[number, number]>,
@@ -108,10 +178,10 @@ export function optimizeStroke(
 
 /**
  * Get stroke outline using perfect-freehand algorithm
- * Converts array of [x, y] points to smooth outline points
+ * Converts array of [x, y] or [x, y, pressure] points to smooth outline points
  */
 export function getStrokeOutline(
-	points: Array<[number, number]>,
+	points: Array<[number, number]> | Array<[number, number, number]>,
 	options: StrokeOptions = {},
 ): number[][] {
 	const defaultOptions: StrokeOptions = {
@@ -124,12 +194,62 @@ export function getStrokeOutline(
 	};
 
 	// Convert points to format expected by perfect-freehand
-	const strokePoints = points.map(([x, y]) => [x, y, 0.5]);
+	// If pressure is already included, use it; otherwise default to 0.5
+	const strokePoints = points.map((p) =>
+		p.length === 3 ? [p[0], p[1], p[2]] : [p[0], p[1], 0.5],
+	);
 
 	// Get outline from perfect-freehand
 	const outline = getStroke(strokePoints, defaultOptions);
 
 	return outline;
+}
+
+/**
+ * Calculate pressure based on drawing speed
+ * Faster drawing = lower pressure (thinner), slower = higher pressure (thicker)
+ *
+ * @param points - Array of points with timestamps
+ * @returns Array of points with calculated pressure [x, y, pressure]
+ */
+export function calculatePressureFromSpeed(
+	points: Array<[number, number, number]>, // [x, y, timestamp]
+): Array<[number, number, number]> {
+	if (points.length === 0) return [];
+	if (points.length === 1) {
+		const p = points[0];
+		if (!p) return [];
+		return [[p[0], p[1], 0.5]];
+	}
+
+	const result: Array<[number, number, number]> = [];
+
+	// First point gets default pressure
+	const first = points[0];
+	if (first) result.push([first[0], first[1], 0.5]);
+
+	for (let i = 1; i < points.length; i++) {
+		const prev = points[i - 1];
+		const curr = points[i];
+		if (!prev || !curr) continue;
+
+		const dx = curr[0] - prev[0];
+		const dy = curr[1] - prev[1];
+		const dt = curr[2] - prev[2];
+
+		const distance = Math.sqrt(dx * dx + dy * dy);
+		const speed = dt > 0 ? distance / dt : 0;
+
+		// Speed normalization: 0-1 range
+		// Lower speed (< 0.5) = higher pressure (thicker)
+		// Higher speed (> 0.5) = lower pressure (thinner)
+		const normalizedSpeed = Math.min(1, speed / 2);
+		const pressure = 1 - normalizedSpeed * 0.6; // Range: 0.4 to 1.0
+
+		result.push([curr[0], curr[1], pressure]);
+	}
+
+	return result;
 }
 
 // ============================================================================
@@ -146,8 +266,14 @@ export function outlineToFlatArray(outline: number[][]): number[] {
 /**
  * Convert outline to SVG path data for Konva Path component
  * This creates smooth, variable-width strokes
+ *
+ * @param points - Array of [x, y] or [x, y, pressure] points
+ * @param options - Stroke options (size, thinning, etc.)
  */
-export function outlineToSvgPath(points: Array<[number, number]>): string {
+export function outlineToSvgPath(
+	points: Array<[number, number]> | Array<[number, number, number]>,
+	options?: StrokeOptions,
+): string {
 	if (points.length === 0) return "";
 	if (points.length === 1) {
 		const point = points[0];
@@ -157,7 +283,7 @@ export function outlineToSvgPath(points: Array<[number, number]>): string {
 	}
 
 	// Get stroke outline from perfect-freehand
-	const outline = getStrokeOutline(points);
+	const outline = getStrokeOutline(points, options);
 
 	if (outline.length === 0) return "";
 	const firstOutlinePoint = outline[0];

--- a/canvas/apps/web/store/canvas-store.ts
+++ b/canvas/apps/web/store/canvas-store.ts
@@ -625,14 +625,18 @@ export const useSelectedElements = () => {
 };
 
 /**
- * Get elements as array (for rendering)
+ * Get elements as array, sorted by zIndex (for correct rendering order)
  *
  * useShallow prevents infinite loops by doing shallow comparison
  * of array contents instead of reference equality
  */
 export const useElementsArray = () => {
 	return useCanvasStore(
-		useShallow((state) => Array.from(state.elements.values())),
+		useShallow((state) =>
+			Array.from(state.elements.values()).sort(
+				(a, b) => (a.zIndex || 0) - (b.zIndex || 0),
+			),
+		),
 	);
 };
 

--- a/canvas/packages/common/src/canvas.types.ts
+++ b/canvas/packages/common/src/canvas.types.ts
@@ -291,7 +291,8 @@ export type Tool =
 	| "diamond" // Draw diamonds
 	| "line" // Draw lines
 	| "arrow" // Draw arrows
-	| "freedraw" // Freehand drawing
+	| "freedraw" // Freehand drawing (persistent)
+	| "laser" // Laser pointer (temporary)
 	| "text" // Add text
 	| "eraser" // Erase elements
 	| "hand"; // Pan canvas


### PR DESCRIPTION
## Summary
Fixed - the Issue fix fronted bugs #30


This PR addresses multiple canvas interaction bugs that were affecting the drawing and editing experience.

## Changes

### 🎯 Laser Tool Positioning
- Fixed laser strokes appearing offset from the cursor
- Added proper x/y coordinates to the laser Path component using `interactionStartPoint`

### ✏️ Freedraw Selection & Editing
- Freehand strokes can now be selected and edited after drawing
- Implemented custom `getElementAtPoint()` hit detection for accurate selection
- Added dashed/dotted stroke style support for freedraw elements

### 📚 Z-Index Layering Commands
- Fixed "Send Backward", "Send to Back", "Bring Forward", "Bring to Front" commands
- Added `getNextZIndex()` helper function for consistent z-index assignment
- Implemented proper zIndex swapping logic for layering operations

### 🔄 Rotation Controls with Zoom/Pan Support
- Fixed rotation breaking after layering refactor
- Added `zoom`, `scrollX`, `scrollY` props to RotationControls
- Properly convert screen coordinates to canvas coordinates: `(screenPos - scroll) / zoom`
- Fixed selection logic to preserve selection during rotation interactions

### ⚛️ Hydration Error Fix
- Fixed React hydration mismatch in Input component
- Added `type="text"` as default prop to prevent server/client mismatch

## Files Changed

- `apps/web/components/Canvas.tsx`
- `apps/web/components/canvas/RotationControls.tsx`
- `apps/web/components/ui/Input.tsx`
- `apps/web/store/canvas-store.ts`

## Testing

- [x] Laser tool draws at cursor position
- [x] Freedraw strokes are selectable and editable
- [x] Layering commands work correctly
- [x] Rotation works at all zoom levels
- [x] No hydration errors in console
