### PR TITLE
feat: live collaborative ghost stroke preview via Y.js awareness

### DIFF
--- a/canvas/apps/web/components/canvas/GhostLayer.tsx
+++ b/canvas/apps/web/components/canvas/GhostLayer.tsx
@@ -1,0 +1,298 @@
+/**
+ * ============================================================================
+ * LEKHAFLOW - GHOST LAYER COMPONENT
+ * ============================================================================
+ *
+ * Renders translucent previews of what remote users are currently drawing.
+ *
+ * ISOLATION GUARANTEES:
+ * - listening={false} → no pointer events, no selection conflicts
+ * - Separate <Layer> → not part of the main shapes layer
+ * - No zIndex system involvement
+ * - No Y.js document involvement
+ * - No rotation/resize handle interference
+ * - Memoized to prevent unnecessary re-renders
+ */
+
+"use client";
+
+import { memo } from "react";
+import {
+	Arrow,
+	Ellipse,
+	Group,
+	Layer,
+	Line,
+	Path,
+	Rect,
+	Text,
+} from "react-konva";
+import type { RemoteGhost } from "../../hooks/useGhostPreviews";
+import { outlineToSvgPath } from "../../lib/stroke-utils";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** Ghost opacity for translucent preview */
+const GHOST_OPACITY = 0.35;
+
+/** Dash pattern for ghost outlines */
+const GHOST_DASH = [8, 4];
+
+// ============================================================================
+// GHOST SHAPE RENDERER
+// ============================================================================
+
+/**
+ * Renders a single ghost shape based on its type.
+ * All ghosts are non-interactive:
+ * - No selection
+ * - No dragging
+ * - No resize handles
+ * - No rotation handles
+ */
+const GhostShape = memo(({ ghost }: { ghost: RemoteGhost }) => {
+	const { preview, clientId } = ghost;
+	const {
+		type,
+		x,
+		y,
+		width,
+		height,
+		points,
+		strokeColor,
+		strokeWidth,
+		fillColor,
+		clientName,
+	} = preview;
+
+	// Use client color tint if available, otherwise stroke color
+	const ghostStroke = preview.clientColor || strokeColor || "#888888";
+	const ghostFill = fillColor ? `${fillColor}40` : "transparent"; // 25% alpha fill
+
+	// Common props for all ghost shapes — ensures no interaction
+	const commonProps = {
+		opacity: GHOST_OPACITY,
+		dash: GHOST_DASH,
+		listening: false,
+		perfectDrawEnabled: false,
+	};
+
+	const labelText = clientName || `User ${clientId}`;
+
+	switch (type) {
+		case "rectangle":
+			return (
+				<Group>
+					<Rect
+						x={x}
+						y={y}
+						width={width}
+						height={height}
+						stroke={ghostStroke}
+						strokeWidth={strokeWidth}
+						fill={ghostFill}
+						{...commonProps}
+					/>
+					<Text
+						x={x}
+						y={y - 18}
+						text={labelText}
+						fontSize={11}
+						fill={ghostStroke}
+						opacity={0.6}
+						listening={false}
+					/>
+				</Group>
+			);
+
+		case "ellipse":
+			return (
+				<Group>
+					<Ellipse
+						x={x + width / 2}
+						y={y + height / 2}
+						radiusX={Math.abs(width / 2)}
+						radiusY={Math.abs(height / 2)}
+						stroke={ghostStroke}
+						strokeWidth={strokeWidth}
+						fill={ghostFill}
+						{...commonProps}
+					/>
+					<Text
+						x={x}
+						y={y - 18}
+						text={labelText}
+						fontSize={11}
+						fill={ghostStroke}
+						opacity={0.6}
+						listening={false}
+					/>
+				</Group>
+			);
+
+		case "diamond": {
+			const cx = width / 2;
+			const cy = height / 2;
+			const diamondPoints = [cx, 0, width, cy, cx, height, 0, cy];
+			return (
+				<Group>
+					<Line
+						x={x}
+						y={y}
+						points={diamondPoints}
+						closed
+						stroke={ghostStroke}
+						strokeWidth={strokeWidth}
+						fill={ghostFill}
+						{...commonProps}
+					/>
+					<Text
+						x={x}
+						y={y - 18}
+						text={labelText}
+						fontSize={11}
+						fill={ghostStroke}
+						opacity={0.6}
+						listening={false}
+					/>
+				</Group>
+			);
+		}
+
+		case "line":
+			return (
+				<Group>
+					<Line
+						x={x}
+						y={y}
+						points={points}
+						stroke={ghostStroke}
+						strokeWidth={strokeWidth}
+						{...commonProps}
+					/>
+					<Text
+						x={x + (points[0] || 0)}
+						y={y + (points[1] || 0) - 18}
+						text={labelText}
+						fontSize={11}
+						fill={ghostStroke}
+						opacity={0.6}
+						listening={false}
+					/>
+				</Group>
+			);
+
+		case "arrow":
+			return (
+				<Group>
+					<Arrow
+						x={x}
+						y={y}
+						points={points}
+						stroke={ghostStroke}
+						strokeWidth={strokeWidth}
+						pointerLength={10}
+						pointerWidth={10}
+						fill={ghostStroke}
+						{...commonProps}
+					/>
+					<Text
+						x={x + (points[0] || 0)}
+						y={y + (points[1] || 0) - 18}
+						text={labelText}
+						fontSize={11}
+						fill={ghostStroke}
+						opacity={0.6}
+						listening={false}
+					/>
+				</Group>
+			);
+
+		case "freedraw":
+		case "freehand": {
+			if (!points || points.length < 4) return null;
+
+			// Convert flat [x,y,x,y,...] to [[x,y],[x,y],...] for perfect-freehand
+			const pointPairs: Array<[number, number]> = [];
+			for (let i = 0; i < points.length; i += 2) {
+				const px = points[i];
+				const py = points[i + 1];
+				if (px !== undefined && py !== undefined) {
+					pointPairs.push([px, py]);
+				}
+			}
+
+			const pathData = outlineToSvgPath(pointPairs, {
+				size: strokeWidth * 2,
+				thinning: 0.5,
+				smoothing: 0.5,
+				streamline: 0.5,
+				simulatePressure: true,
+			});
+
+			if (!pathData) return null;
+
+			return (
+				<Group>
+					<Path
+						x={x}
+						y={y}
+						data={pathData}
+						fill={`${ghostStroke}59`} // 35% alpha
+						{...commonProps}
+					/>
+					<Text
+						x={x + (pointPairs[0]?.[0] || 0)}
+						y={y + (pointPairs[0]?.[1] || 0) - 18}
+						text={labelText}
+						fontSize={11}
+						fill={ghostStroke}
+						opacity={0.6}
+						listening={false}
+					/>
+				</Group>
+			);
+		}
+
+		default:
+			return null;
+	}
+});
+
+GhostShape.displayName = "GhostShape";
+
+// ============================================================================
+// GHOST LAYER
+// ============================================================================
+
+interface GhostLayerProps {
+	remoteGhosts: RemoteGhost[];
+}
+
+/**
+ * GhostLayer — Rendered above the shapes layer, below UI controls
+ *
+ * listening={false} ensures:
+ * - No pointer events reach ghost shapes
+ * - No interference with selection system
+ * - No interference with rotation handles
+ * - No interference with resize handles
+ * - No interference with drag/drop
+ */
+const GhostLayer = memo(({ remoteGhosts }: GhostLayerProps) => {
+	if (remoteGhosts.length === 0) return null;
+
+	return (
+		<Layer name="ghost-layer" listening={false}>
+			{remoteGhosts.map((ghost) => (
+				<GhostShape key={`ghost-${ghost.clientId}`} ghost={ghost} />
+			))}
+		</Layer>
+	);
+});
+
+GhostLayer.displayName = "GhostLayer";
+
+export default GhostLayer;

--- a/canvas/apps/web/components/ui/Input.tsx
+++ b/canvas/apps/web/components/ui/Input.tsx
@@ -8,6 +8,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 		return (
 			<input
 				type={type}
+				suppressHydrationWarning
 				className={`
           flex h-10 w-full rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400
           focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent transition-all duration-200

--- a/canvas/apps/web/hooks/useGhostPreviews.ts
+++ b/canvas/apps/web/hooks/useGhostPreviews.ts
@@ -1,0 +1,213 @@
+/**
+ * ============================================================================
+ * LEKHAFLOW - GHOST PREVIEW HOOK
+ * ============================================================================
+ *
+ * Manages live collaborative ghost stroke previews via Y.js awareness protocol.
+ *
+ * KEY DESIGN DECISIONS:
+ * - Uses awareness protocol (NOT Y.Doc) → no document writes until commit
+ * - Throttled broadcasts (~60fps) to avoid flooding the network
+ * - Stale ghost cleanup handles disconnected clients
+ * - Completely isolated from zIndex, selection, rotation systems
+ *
+ * DATA FLOW:
+ * 1. Local user draws → broadcastGhost() sends preview via awareness
+ * 2. Remote users receive awareness change → remoteGhosts[] updated
+ * 3. GhostLayer renders translucent previews
+ * 4. On mouseup → clearGhost() removes preview, real shape committed to Y.Doc
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/**
+ * Ghost Preview Data Structure
+ * Broadcast via Y.js awareness (NOT Y.Doc)
+ * Lightweight — only contains rendering-critical fields
+ */
+export interface GhostPreview {
+	/** Element type being drawn */
+	type:
+		| "rectangle"
+		| "ellipse"
+		| "diamond"
+		| "line"
+		| "arrow"
+		| "freedraw"
+		| "freehand";
+	/** Starting x coordinate (canvas space) */
+	x: number;
+	/** Starting y coordinate (canvas space) */
+	y: number;
+	/** Current width (for shapes) */
+	width: number;
+	/** Current height (for shapes) */
+	height: number;
+	/** Flat points array [x,y,x,y,...] for line/arrow/freedraw/freehand */
+	points: number[];
+	/** Stroke color */
+	strokeColor: string;
+	/** Stroke width */
+	strokeWidth: number;
+	/** Fill color (for shapes) */
+	fillColor: string;
+	/** Stroke style */
+	strokeStyle: "solid" | "dashed" | "dotted";
+	/** Client display name */
+	clientName: string;
+	/** Client color tint for ghost differentiation */
+	clientColor: string;
+	/** Timestamp for staleness detection */
+	timestamp: number;
+}
+
+/** Remote ghost with client ID attached */
+export interface RemoteGhost {
+	clientId: number;
+	preview: GhostPreview;
+}
+
+/**
+ * Awareness interface matching HocuspocusProvider.awareness
+ * Using structural typing to avoid import coupling
+ */
+interface AwarenessLike {
+	clientID: number;
+	setLocalStateField: (field: string, value: unknown) => void;
+	getStates: () => Map<number, Record<string, unknown>>;
+	on: (event: string, callback: (...args: unknown[]) => void) => void;
+	off: (event: string, callback: (...args: unknown[]) => void) => void;
+}
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** Throttle interval for awareness updates (ms) - ~60fps cap */
+const THROTTLE_MS = 16;
+
+/** Stale ghost timeout (ms) - remove ghosts older than this */
+const STALE_TIMEOUT = 5000;
+
+// ============================================================================
+// HOOK IMPLEMENTATION
+// ============================================================================
+
+/**
+ * Hook: useGhostPreviews
+ *
+ * Manages ghost stroke previews via Y.js awareness protocol.
+ *
+ * @param awareness - HocuspocusProvider awareness instance (null when not connected)
+ * @returns { remoteGhosts, broadcastGhost, clearGhost }
+ */
+export function useGhostPreviews(awareness: AwarenessLike | null) {
+	const [remoteGhosts, setRemoteGhosts] = useState<RemoteGhost[]>([]);
+	const lastBroadcastRef = useRef<number>(0);
+	const staleCleanupRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+	// ─────────────────────────────────────────────────────────────────
+	// BROADCAST: Send local drawing preview to remote users
+	// ─────────────────────────────────────────────────────────────────
+
+	/**
+	 * Broadcast local ghost preview via awareness
+	 * Throttled to THROTTLE_MS to avoid flooding the network
+	 */
+	const broadcastGhost = useCallback(
+		(preview: Omit<GhostPreview, "timestamp">) => {
+			if (!awareness) return;
+
+			const now = Date.now();
+			if (now - lastBroadcastRef.current < THROTTLE_MS) return;
+			lastBroadcastRef.current = now;
+
+			awareness.setLocalStateField("drawingPreview", {
+				...preview,
+				timestamp: now,
+			});
+		},
+		[awareness],
+	);
+
+	// ─────────────────────────────────────────────────────────────────
+	// CLEAR: Remove local ghost preview from awareness
+	// ─────────────────────────────────────────────────────────────────
+
+	/**
+	 * Clear local ghost preview from awareness
+	 * Called on mouseup, tool switch, or drawing cancel
+	 */
+	const clearGhost = useCallback(() => {
+		if (!awareness) return;
+		awareness.setLocalStateField("drawingPreview", null);
+	}, [awareness]);
+
+	// ─────────────────────────────────────────────────────────────────
+	// SUBSCRIBE: Listen for remote users' drawing previews
+	// ─────────────────────────────────────────────────────────────────
+
+	useEffect(() => {
+		if (!awareness) return;
+
+		const handleAwarenessChange = () => {
+			const states = awareness.getStates();
+			const ghosts: RemoteGhost[] = [];
+			const localId = awareness.clientID;
+
+			states.forEach((state, clientId) => {
+				// Skip local client — we render our own drawingElement directly
+				if (clientId === localId) return;
+
+				if (state.drawingPreview) {
+					ghosts.push({
+						clientId,
+						preview: state.drawingPreview as GhostPreview,
+					});
+				}
+			});
+
+			setRemoteGhosts(ghosts);
+		};
+
+		awareness.on("change", handleAwarenessChange);
+
+		// Initial read in case there are already active ghosts
+		handleAwarenessChange();
+
+		return () => {
+			awareness.off("change", handleAwarenessChange);
+		};
+	}, [awareness]);
+
+	// ─────────────────────────────────────────────────────────────────
+	// CLEANUP: Remove stale ghosts from disconnected clients
+	// ─────────────────────────────────────────────────────────────────
+
+	useEffect(() => {
+		staleCleanupRef.current = setInterval(() => {
+			const now = Date.now();
+			setRemoteGhosts((prev) =>
+				prev.filter((ghost) => now - ghost.preview.timestamp < STALE_TIMEOUT),
+			);
+		}, STALE_TIMEOUT);
+
+		return () => {
+			if (staleCleanupRef.current) {
+				clearInterval(staleCleanupRef.current);
+			}
+		};
+	}, []);
+
+	return {
+		remoteGhosts,
+		broadcastGhost,
+		clearGhost,
+	};
+}

--- a/canvas/apps/web/hooks/useYjsSync.ts
+++ b/canvas/apps/web/hooks/useYjsSync.ts
@@ -46,6 +46,18 @@ interface AwarenessState {
 /**
  * Return type of the hook
  */
+/**
+ * Awareness interface for ghost preview broadcasting
+ * Matches HocuspocusProvider.awareness API surface
+ */
+export interface AwarenessInstance {
+	clientID: number;
+	setLocalStateField: (field: string, value: unknown) => void;
+	getStates: () => Map<number, Record<string, unknown>>;
+	on: (event: string, callback: (...args: unknown[]) => void) => void;
+	off: (event: string, callback: (...args: unknown[]) => void) => void;
+}
+
 interface UseYjsSyncReturn {
 	doc: Y.Doc;
 	provider: HocuspocusProvider | null;
@@ -59,6 +71,8 @@ interface UseYjsSyncReturn {
 	redo: () => void;
 	canUndo: boolean;
 	canRedo: boolean;
+	/** Y.js awareness instance for ghost preview broadcasting */
+	awareness: AwarenessInstance | null;
 }
 
 // ============================================================================
@@ -394,5 +408,6 @@ export function useYjsSync(
 		redo,
 		canUndo,
 		canRedo,
+		awareness: (providerRef.current?.awareness as AwarenessInstance) ?? null,
 	};
 }


### PR DESCRIPTION
## Summary

Implements real-time ghost stroke previews for collaborative drawing sessions. While a user is actively drawing, all other connected users see a live translucent preview of the in-progress shape — before it is committed to the Y.js document. Also includes a hydration mismatch fix for the shared `Input` component.

---

## Changes

### New: `hooks/useGhostPreviews.ts`
- New hook that manages live ghost previews via the **Y.js awareness protocol** (not Y.Doc — no writes until `mouseup`)
- Broadcasts the local user's current drawing state via `awareness.setLocalStateField("drawingPreview", ...)`
- Subscribes to remote awareness changes and surfaces them as `remoteGhosts[]`
- Throttled to ~60fps (16ms) to avoid network flooding
- Stale ghost cleanup every 5s to handle disconnected clients
- Exports `GhostPreview` and `RemoteGhost` types

### New: `components/canvas/GhostLayer.tsx`
- New Konva `<Layer>` that renders translucent previews of what remote users are drawing
- Fully isolated: `listening={false}` — no pointer events, no selection/rotation/resize interference
- Renders all supported element types: `rectangle`, `ellipse`, `diamond`, `line`, `arrow`, `freedraw`/`freehand`
- Uses `outlineToSvgPath` (perfect-freehand) for variable-width freedraw ghost paths
- Shows a floating client name label above each ghost shape
- Ghost opacity: 35%, dashed outline (8px dash / 4px gap)
- Memoized (`React.memo`) to prevent unnecessary re-renders

### Modified: `hooks/useYjsSync.ts`
- Exported new `AwarenessInstance` interface (structural type matching `HocuspocusProvider.awareness`)
- Added `awareness: AwarenessInstance | null` to the `UseYjsSyncReturn` interface and return value
- Exposes the provider's awareness instance to consumers without coupling to Hocuspocus types directly

### Modified: `components/Canvas.tsx`
- Destructures `awareness` from `useYjsSync` and passes it to `useGhostPreviews`
- Added `broadcastDrawingPreview()` helper — converts `CanvasElement` data to `GhostPreview` format, handles all point formats (flat arrays, tuple arrays, object arrays)
- Calls `broadcastDrawingPreview()` inside `handleMouseMove` for all drawing cases: shapes (rectangle/ellipse/diamond), line/arrow, and freedraw
- Calls `clearGhost()` at the start of `handleMouseUp` — removes preview as soon as the shape is committed
- Clears ghost on tool switch via `useEffect([activeTool])`
- Renders `<GhostLayer remoteGhosts={remoteGhosts} />` inside the Konva `<Stage>`, above the main shapes layer

### Fixed: `components/ui/Input.tsx`
- Added `suppressHydrationWarning` to `<input>` to silence the React hydration mismatch caused by browser extension attribute injection (`wfd-id`) on the home page room-join input

---

## Architecture Notes

- Ghost data flows entirely through **Y.js awareness** — a separate ephemeral channel from the Y.Doc CRDT. Nothing is written to the document until `mouseup`.
- No existing systems are affected: z-index layering, element selection, rotation handles, resize handles, and drag-drop all remain isolated from the ghost layer.
- The ghost layer is the last `<Layer>` inside `<Stage>`, rendered above everything else but with `listening={false}` so it captures no events.

---

## Testing

- TypeScript: `npx tsc --noEmit` — ✅ clean
- Biome lint: `npx biome check` — ✅ clean (4 files)
- Manual: open two browser tabs on the same room and draw — ghost previews appear in real time on the other tab